### PR TITLE
Deprecation: Drop nice and sock_backlog options that are deprecated in conntrackd

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -68,7 +68,6 @@ The following parameters are available in the `conntrackd` class:
 * [`syslog`](#-conntrackd--syslog)
 * [`lockfile`](#-conntrackd--lockfile)
 * [`sock_path`](#-conntrackd--sock_path)
-* [`sock_backlog`](#-conntrackd--sock_backlog)
 * [`ignore_ips_ipv4`](#-conntrackd--ignore_ips_ipv4)
 * [`ignore_ips_ipv6`](#-conntrackd--ignore_ips_ipv6)
 * [`tcp_flows`](#-conntrackd--tcp_flows)
@@ -252,13 +251,6 @@ Data type: `String`
 
 string:  fully qualified path to the UNIX socket used for configuration
 Default: <tt>/var/run/conntrackd.ctl</tt>
-
-##### <a name="-conntrackd--sock_backlog"></a>`sock_backlog`
-
-Data type: `Integer`
-
-integer: sets the blacklog ofr the UNIX socket
-Default: <tt>20</tt>
 
 ##### <a name="-conntrackd--ignore_ips_ipv4"></a>`ignore_ips_ipv4`
 
@@ -592,7 +584,6 @@ The following parameters are available in the `conntrackd::config` class:
 * [`syslog`](#-conntrackd--config--syslog)
 * [`lockfile`](#-conntrackd--config--lockfile)
 * [`sock_path`](#-conntrackd--config--sock_path)
-* [`sock_backlog`](#-conntrackd--config--sock_backlog)
 * [`ignore_ips_ipv4`](#-conntrackd--config--ignore_ips_ipv4)
 * [`ignore_ips_ipv6`](#-conntrackd--config--ignore_ips_ipv6)
 * [`tcp_flows`](#-conntrackd--config--tcp_flows)
@@ -698,15 +689,6 @@ string:  fully qualified path to the UNIX socket used for configuration
 Default: <tt>/var/run/conntrackd.ctl</tt>
 
 Default value: `$conntrackd::sock_path`
-
-##### <a name="-conntrackd--config--sock_backlog"></a>`sock_backlog`
-
-Data type: `Integer`
-
-integer: sets the blacklog ofr the UNIX socket
-Default: <tt>20</tt>
-
-Default value: `$conntrackd::sock_backlog`
 
 ##### <a name="-conntrackd--config--ignore_ips_ipv4"></a>`ignore_ips_ipv4`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -63,7 +63,6 @@ The following parameters are available in the `conntrackd` class:
 * [`service_status`](#-conntrackd--service_status)
 * [`config_dir`](#-conntrackd--config_dir)
 * [`config_filename`](#-conntrackd--config_filename)
-* [`nice`](#-conntrackd--nice)
 * [`hashsize`](#-conntrackd--hashsize)
 * [`logfile`](#-conntrackd--logfile)
 * [`syslog`](#-conntrackd--syslog)
@@ -215,14 +214,6 @@ Top-level directory for configuration
 Data type: `String`
 
 Config file name
-
-##### <a name="-conntrackd--nice"></a>`nice`
-
-Data type: `Integer[-20,19]`
-
-integer: Nice value of the conntrackd process
-range: <tt>-19</tt> to <tt>+19</tt>
-Default: <tt>-1</tt>
 
 ##### <a name="-conntrackd--hashsize"></a>`hashsize`
 
@@ -595,7 +586,6 @@ Default value: `undef`
 The following parameters are available in the `conntrackd::config` class:
 
 * [`ensure`](#-conntrackd--config--ensure)
-* [`nice`](#-conntrackd--config--nice)
 * [`hashsize`](#-conntrackd--config--hashsize)
 * [`hashlimit`](#-conntrackd--config--hashlimit)
 * [`logfile`](#-conntrackd--config--logfile)
@@ -651,16 +641,6 @@ String. Controls if the managed resources shall be <tt>present</tt> or
 Default: <tt>present</tt>.
 
 Default value: `$conntrackd::ensure`
-
-##### <a name="-conntrackd--config--nice"></a>`nice`
-
-Data type: `Integer[-20,19]`
-
-integer: Nice value of the conntrackd process
-range: <tt>-19</tt> to <tt>+19</tt>
-Default: <tt>-1</tt>
-
-Default value: `$conntrackd::nice`
 
 ##### <a name="-conntrackd--config--hashsize"></a>`hashsize`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -26,7 +26,6 @@ conntrackd::logfile: 'off'
 conntrackd::syslog: 'on'
 conntrackd::lockfile: '/var/lock/conntrack.lock'
 conntrackd::sock_path: '/var/run/conntrackd.ctl'
-conntrackd::sock_backlog: 20
 conntrackd::ignore_ips_ipv4:
   - '127.0.0.1'
   - '192.168.0.1'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -21,7 +21,6 @@ conntrackd::config_dir: '/etc/conntrackd'
 conntrackd::config_filename: 'conntrackd.conf'
 
 # Configuration file parameters
-conntrackd::nice: -1
 conntrackd::hashsize: 32768
 conntrackd::logfile: 'off'
 conntrackd::syslog: 'on'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,11 +7,6 @@
 #   <tt>absent</tt>.
 #   Default: <tt>present</tt>.
 #
-# @param nice
-#   integer: Nice value of the conntrackd process
-#   range: <tt>-19</tt> to <tt>+19</tt>
-#   Default: <tt>-1</tt>
-#
 # @param hashsize
 #   integer: Number of buckets in the cache hashtable.
 #   Default: <tt>32768</tt>
@@ -242,7 +237,6 @@
 class conntrackd::config (
   Enum['present', 'absent']        $ensure                     = $conntrackd::ensure,
   Enum['Multicast', 'UDP']         $protocol                   = $conntrackd::protocol,
-  Integer[-20,19]                  $nice                       = $conntrackd::nice,
   Integer                          $hashsize                   = $conntrackd::hashsize,
   Integer                          $hashlimit                  = $conntrackd::_hashlimit,
   String                           $logfile                    = $conntrackd::logfile,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,10 +34,6 @@
 #   string:  fully qualified path to the UNIX socket used for configuration
 #   Default: <tt>/var/run/conntrackd.ctl</tt>
 #
-# @param sock_backlog
-#   integer: sets the blacklog ofr the UNIX socket
-#   Default: <tt>20</tt>
-#
 # @param ignore_ips_ipv4
 #   array:   list of IPv4 addresses to ignore.
 #            should include this node's address
@@ -243,7 +239,6 @@ class conntrackd::config (
   String                           $syslog                     = $conntrackd::syslog,
   String                           $lockfile                   = $conntrackd::lockfile,
   String                           $sock_path                  = $conntrackd::sock_path,
-  Integer                          $sock_backlog               = $conntrackd::sock_backlog,
   Array                            $ignore_ips_ipv4            = $conntrackd::ignore_ips_ipv4,
   Array                            $ignore_ips_ipv6            = $conntrackd::ignore_ips_ipv6,
   Array                            $tcp_flows                  = $conntrackd::tcp_flows,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,11 +52,6 @@
 # @param config_dir Top-level directory for configuration
 # @param config_filename Config file name
 #
-# @param nice
-#   integer: Nice value of the conntrackd process
-#   range: <tt>-19</tt> to <tt>+19</tt>
-#   Default: <tt>-1</tt>
-#
 # @param hashsize
 #   integer: Number of buckets in the cache hashtable.
 #   Default: <tt>32768</tt>
@@ -317,7 +312,6 @@ class conntrackd (
   String                           $service_status,
   String                           $config_dir,
   String                           $config_filename,
-  Integer[-20,19]                  $nice,
   Integer                          $hashsize,
   String                           $logfile,
   String                           $syslog,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,10 +75,6 @@
 #   string:  fully qualified path to the UNIX socket used for configuration
 #   Default: <tt>/var/run/conntrackd.ctl</tt>
 #
-# @param sock_backlog
-#   integer: sets the blacklog ofr the UNIX socket
-#   Default: <tt>20</tt>
-#
 # @param ignore_ips_ipv4
 #   array:   list of IPv4 addresses to ignore.
 #            should include this node's address
@@ -317,7 +313,6 @@ class conntrackd (
   String                           $syslog,
   String                           $lockfile,
   String                           $sock_path,
-  Integer                          $sock_backlog,
   Array                            $ignore_ips_ipv4,
   Array                            $ignore_ips_ipv6,
   Array                            $tcp_flows,

--- a/templates/conntrackd.conf.epp
+++ b/templates/conntrackd.conf.epp
@@ -48,7 +48,6 @@ Sync {
 }
 
 General {
-	Nice <%= $conntrackd::config::nice %>
 
 	Scheduler {
 		Type <%= $conntrackd::config::scheduler_type %>

--- a/templates/conntrackd.conf.epp
+++ b/templates/conntrackd.conf.epp
@@ -62,7 +62,6 @@ General {
 
 	UNIX {
 		Path <%= $conntrackd::config::sock_path %>
-		Backlog <%= $conntrackd::config::sock_backlog %>
 	}
 
 	NetlinkBufferSize <%= $conntrackd::config::netlinkbuffersize %>


### PR DESCRIPTION
https://manpages.debian.org/testing/conntrackd/conntrackd.conf.5.en.html#Nice
http://git.netfilter.org/conntrack-tools/tree/conntrackd.conf.5#n483

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Remove deprecated option 
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
