### PR TITLE
adapt template to not add empty address lines

### DIFF
--- a/templates/conntrackd.conf.epp
+++ b/templates/conntrackd.conf.epp
@@ -87,10 +87,10 @@ General {
 
 		Address Ignore {
 <% $conntrackd::config::ignore_ips_ipv4.each |$address| { -%>
-			IPv4_address <%= $address %>
+			<% if $address != '' { %>IPv4_address <%= $address %><% } %>
 <% } -%>
 <% $conntrackd::config::ignore_ips_ipv6.each |$address| { -%>
-			IPv6_address <%= $address %>
+			<% if $address != '' { %>IPv6_address <%= $address %><% } %>
 <% } -%>
 		}
 		State Accept {


### PR DESCRIPTION
if network facts are used to specify ignored ip addresses, and puppet is used to configure the network interfaces the ip address fact only available after the first successful puppet run (or even a reboot, if you do not reconfigure network interfaces with puppet).
Currently the situation leads to an incorrect conntrackd configuration which fails starting conntrackd.
This patch ignores the empty address fields so conntrackd is not failing after first run.
(reconfiguration in second run is still guaranted)

